### PR TITLE
Add new message

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,8 +18,34 @@ Documentation for each message type supported in `ark_msgs` can be found below.
 
 ## Table of Contents
 
+- [Core](#core)
 - [Geometry](#geometry)
 - [Sensor](#sensor)
+
+## Core
+
+Core messages used by Ark.
+
+### ArkMessage
+
+This is the message that is actually sent across the network.
+
+##### Fields
+
+- `timestamp`: the timestamp when the message was sent
+- `payload_msg_type`: the type of the payload message as a string
+- `payload`: the payload of the message as bytes
+
+##### Helpers
+
+- `ArkMessage.pack(clock, msg)`  
+  Packs a message as an ArkMessage with the timestamp from the clock (`ark.clock.Clock`).
+- `ArkMessage.from_sample(sample)`
+  Retreive the `ArkMessage` from the given Zenoh sample. 
+
+##### Usage
+
+`ArkMessage` is not designed for user code, so should not be used.
 
 ## Geometry
 

--- a/proto/ark_msgs/ark_message.proto
+++ b/proto/ark_msgs/ark_message.proto
@@ -1,0 +1,10 @@
+syntax = "proto3";
+
+package ark_msgs;
+
+// Ark message that is sent on each channel.
+message ArkMessage {
+  uint64 timestamp = 1;
+  string payload_msg_type = 2;
+  bytes payload = 3;
+}

--- a/src/ark_msgs/ark_message.py
+++ b/src/ark_msgs/ark_message.py
@@ -1,0 +1,31 @@
+import zenoh
+from ark.clock import Clock
+from ark_msgs import msgs
+from google.protobuf.message import Message
+from ark_msgs.ark_message_pb2 import ArkMessage
+
+
+@classmethod
+def pack(cls: type[ArkMessage], clock: Clock, msg: Message) -> ArkMessage:
+    return cls(
+        timestamp=clock.now(),
+        payload_msg_type=msg.DESCRIPTOR.full_name,
+        payload=msg.SerializeToString(),
+    )
+
+
+@classmethod
+def from_sample(cls: type[ArkMessage], sample: zenoh.Sample) -> ArkMessage:
+    ark_msg = cls()
+    ark_msg.ParseFromString(bytes(sample.payload))
+    return ark_msg
+
+
+if not hasattr(ArkMessage, "pack"):
+    ArkMessage.pack = pack
+if not hasattr(ArkMessage, "from_sample"):
+    ArkMessage.from_sample = from_sample
+
+msgs.register_item(ArkMessage)
+
+__all__ = ["ArkMessage"]


### PR DESCRIPTION
Adding the `ArkMessage` message.

If you are adding a new message type, you must
- [x] provide the `.proto` file in `proto/ark_msgs`, one message type per file
- [x] provide helper method where necessary, eg. see Geometry message types
- [x] provide documentation in the `README.md`
  - a new group called "core" was created